### PR TITLE
Add all other properties to the token response

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ GoogleSignIn-Swift is compatible with [Swift Package Manager](https://swift.org/
   
     Replace `REDIRECT_URI_SCHEME` with your `CLIENT_ID` using reverse domain notation. For example: `com.googleusercontent.apps.1234-abcd`.
   
-5. Handle redirection after user signs in to obtain oAuth Access Token by calling `getAccessToken` function on `GoogleSignIn.Controller`.
+5. Handle redirection after user signs in to obtain oAuth tokens (access, ID and refresh) by calling `getTokenResponse` function on `GoogleSignIn.Controller`.
 
     For iOS app, you can do it by implementing this function in your `UIApplicationDelegate`:
   
     ```swift
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        controller.getAccessToken(using: url) { result in
-            if case let .success(token) = result {
-                print("ACCESS TOKEN: \(token)")
+        controller.getTokenResponse(using: url) { result in
+            if case let .success(response) = result {
+                print("ACCESS TOKEN: \(response.accessToken)")
             }
         }
         return true
@@ -92,9 +92,9 @@ GoogleSignIn-Swift is compatible with [Swift Package Manager](https://swift.org/
     ```swift
     func scene(_ scene: UIScene, openURLContexts contexts: Set<UIOpenURLContext>) {
         guard let redirectUrl = contexts.first?.url else { return }
-        controller.getAccessToken(using: redirectUrl) { result in
-            if case let .success(token) = result {
-                print("ACCESS TOKEN: \(token)")
+        controller.getTokenResponse(using: redirectUrl) { result in
+            if case let .success(response) = result {
+                print("ACCESS TOKEN: \(response.accessToken)")
             }
         }
     }

--- a/Sources/GoogleSignIn/Controller.swift
+++ b/Sources/GoogleSignIn/Controller.swift
@@ -21,7 +21,7 @@ public class Controller {
         return components.url!
     }
 
-    public func getAccessToken(using redirectUrl: URL, completion: @escaping (Result<Token, Error>) -> Void) {
+    public func getTokenResponse(using redirectUrl: URL, completion: @escaping (Result<TokenResponse, Error>) -> Void) {
         guard let code = self.code(from: redirectUrl) else {
             completion(.failure(.codeNotFoundInRedirectURL))
             return
@@ -81,10 +81,10 @@ public class Controller {
         return components.url!
     }
 
-    private func decodeToken(from data: Data) throws -> Token {
+    private func decodeToken(from data: Data) throws -> TokenResponse {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try decoder.decode(Token.self, from: data)
+        return try decoder.decode(TokenResponse.self, from: data)
     }
 
 }

--- a/Sources/GoogleSignIn/Token.swift
+++ b/Sources/GoogleSignIn/Token.swift
@@ -1,3 +1,0 @@
-public struct Token: Codable, Equatable {
-    public var accessToken: String
-}

--- a/Sources/GoogleSignIn/TokenResponse.swift
+++ b/Sources/GoogleSignIn/TokenResponse.swift
@@ -1,0 +1,8 @@
+public struct TokenResponse: Codable, Equatable {
+    public let accessToken: String
+    public let expiresIn: Int
+    public let idToken: String
+    public let scope: String
+    public let tokenType: String
+    public let refreshToken: String?
+}


### PR DESCRIPTION
There is no reason to assume that the user of the library would only want the `access_token` from the response. The `id_token` is used e.g. for authentication with a custom back-end server as described here: https://developers.google.com/identity/sign-in/ios/backend-auth#using-a-google-api-client-library

This is the reason why all the other JSON response properties should be available and not ignored. In this PR I replaced
```swift
public struct Token: Codable, Equatable {
    public var accessToken: String
}
```
with
```swift
public struct TokenResponse: Codable, Equatable {
    public let accessToken: String
    public let expiresIn: Int
    public let idToken: String
    public let scope: String
    public let tokenType: String
    public let refreshToken: String?
}
```